### PR TITLE
add 5.0 emmc support

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+Building the kernel for flo:
+
+1. sudo apt install gcc-4.9-arm-linux-gnueabihf build-essential
+2. cp debian.flo/config/config.common.ubuntu arch/arm/configs/ubuntu_flo_defconfig
+3. make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- CC=/usr/bin/arm-linux-gnueabihf-gcc-4.9 ubuntu_flo_defconfig
+4. make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- CC=/usr/bin/arm-linux-gnueabihf-gcc-4.9 zImage
+
 	Linux kernel release 3.x <http://kernel.org/>
 
 These are the release notes for Linux version 3.  Read them carefully,

--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -293,7 +293,7 @@ static int mmc_read_ext_csd(struct mmc_card *card, u8 *ext_csd)
 	}
 
 	card->ext_csd.rev = ext_csd[EXT_CSD_REV];
-	if (card->ext_csd.rev > 6) {
+	if (card->ext_csd.rev > 7) {
 		pr_err("%s: unrecognised EXT_CSD revision %d\n",
 			mmc_hostname(card->host), card->ext_csd.rev);
 		err = -EINVAL;


### PR DESCRIPTION
Found by @Stefano0101, [this askubuntu question](https://askubuntu.com/questions/674179/ubuntu-device-flash-fails-on-nexus-7-2013-android-5-0-2-cant-copy-image-to/675499) linked to this patch to bump the maximum MMC version. This is built in https://gitlab.com/ubports/community-ports/flo. Fixes https://github.com/ubports/ubuntu-touch/issues/300